### PR TITLE
Discord OAuth Update Again

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -121,6 +121,7 @@ class Pogom(Flask):
         self.json_encoder = CustomJSONEncoder
         self.route("/", methods=['GET'])(self.fullmap)
         self.route("/auth_callback", methods=['GET'])(self.auth_callback)
+        self.route("/auth_logout", methods=['GET'])(self.auth_logout)
         self.route("/raw_data", methods=['GET'])(self.raw_data)
         self.route("/loc", methods=['GET'])(self.loc)
         self.route("/walk_spawnpoint", methods=['POST'])(self.walk_spawnpoint)
@@ -457,7 +458,7 @@ class Pogom(Flask):
 
     def auth_logout(self):
         session.clear()
-        return make_response(redirect('/'))
+        return make_response(redirect('https://discordapp.com/channels/@me'))
 
     def render_robots_txt(self):
         return render_template('robots.txt')
@@ -1567,8 +1568,6 @@ class Pogom(Flask):
         if request.endpoint == 'submit_token':
             return
         if request.endpoint == 'get_account_stats':
-            return
-        if request.endpoint == 'auth_logout':
             return
 
         return self.discord_api.check_auth(

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -458,7 +458,7 @@ class Pogom(Flask):
 
     def auth_logout(self):
         session.clear()
-        return make_response(redirect('https://discordapp.com/channels/@me'))
+        return make_response(redirect('/'))
 
     def render_robots_txt(self):
         return render_template('robots.txt')

--- a/templates/map.html
+++ b/templates/map.html
@@ -46,7 +46,7 @@
         <a href="#nav"><span class="label">Options</span></a>
         <h1><a href="./">{{mapname}}<img class='rocket icon' src='static/images/rocket.png'></a></h1>
         <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
-        <!-- <a href="auth_logout" style="float: right;"><span class="label">Log-Out</span></a> -->
+        <a href="auth_logout" style="float: right;"><span class="label">Log-Out</span></a>
       </header>
       <!-- NAV -->
       <nav id="nav">


### PR DESCRIPTION
## Description
Enabled to logout link and fixed the functionality. Since there is a logout for the map and a separate one for Discord, the map's logout will redirect to Discord after it clears the session. Users will have to manually log out of the Discord site themselves. 

## Motivation and Context
To allow people a logout option on the map so they can switch accounts.

## How Has This Been Tested?
Yes, on my server.
