### PR TITLE
Fix problem with multiple attributes on endpoints on mapcontrolled

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -4063,6 +4063,7 @@ class Pogom(Flask):
 
             deviceworker = self.get_device(uuid, map_lat, map_lng)
             deviceworker['endpoint'] = endpoint
+            log.info("Device {} change endpoint: {} => {}".format(uuid, deviceworker['endpoint'], endpoint))
 
             return self.save_device(deviceworker, True)
 

--- a/static/js/devices.js
+++ b/static/js/devices.js
@@ -84,7 +84,7 @@ function changeEndpoint(obj) {
     console.log($(this));
     var newendpoint = $(this).val();
     newendpoint = newendpoint.replace("?", "||");
-    newendpoint = newendpoint.replace("&", "|");
+    newendpoint = newendpoint.replace(/&/g, "|");
     console.log(newendpoint);
     $.post('new_endpoint?uuid=' + uuid + '&endpoint=' + newendpoint)
   });


### PR DESCRIPTION
used regex with /g to replace all & instead of only the first

## Motivation and Context
Old solution did only replace first &, allowing only for 2 attributes

## How Has This Been Tested?
Updated and saw that is saved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
